### PR TITLE
Updated HALs section to include embassy-rp, and esp-rs HALs

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -81,6 +81,8 @@ async fn main(spawner: Spawner, p: Peripherals) {
 		<ul>
 			<li><a href="https://docs.embassy.dev/embassy-stm32/">embassy-stm32</a>, for all STM32 microcontroller families.</li>
 			<li><a href="https://docs.embassy.dev/embassy-nrf/">embassy-nrf</a>, for the Nordic Semiconductor nRF52, nRF53, nRF91 series.</li>
+			<li><a href="https://docs.embassy.dev/embassy-rp/">embassy-rp</a>, for the Raspberry Pi RP2040 microcontroller.</li>
+			<li><a href="https://github.com/esp-rs">esp-rs</a>, for the Espressif Systems ESP32 series of chips.</li>
 		</ul>
 	</div>
 	<div>


### PR DESCRIPTION
Added `embassy-rp` and `esp-rs` HALs to the main page. This updates the site so it's got the same information as the README for the HALs.